### PR TITLE
Updating notice for Sublime Text usage policy

### DIFF
--- a/Week0/README.md
+++ b/Week0/README.md
@@ -68,8 +68,10 @@ Any of the ones listed below is fine.
 - [Brackets](http://brackets.io)
 - [Atom](https://atom.io/)
 - [Spacemacs](http://spacemacs.org/)
-- [Sublime (not free)](https://www.sublimetext.com/)
+- [Sublime (*)](https://www.sublimetext.com/)
 
+  _[*] __Sublime Text__ may be downloaded and evaluated for free, however a license must be purchased for continued use._
+  
 If you have no experience or preference when it comes to working with text editor just install Visual studio, you can always switch to another editor later on in the program.
 
 ### Curriculum

--- a/Week1/MAKEME.md
+++ b/Week1/MAKEME.md
@@ -28,7 +28,9 @@
 Before you start check out this [video](http://www.learningscientists.org/videos/) and/or this [article](https://www.cultofpedagogy.com/learning-strategies/) about good learning practices.
 
 #### HTML5
-Read about [HTML5](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/HTML5)
+- Read about [HTML5](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/HTML5)
+- [A page that lists all the HTML elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element)
+- [A page that lists all available HTML attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes)
 
 #### CSS:
 - [CSS reference](http://cssreference.io/)


### PR DESCRIPTION
Although Sublime Text has a 'Pay for continued use' price policy, the 'not free' notice is quite misleading since users are able to download, and use/test the Editor for free without any limitation apart from the regular 'Please consider buying a license ...'.

Once they become familiar with the tool and start using it for commercial purposes, they can buy a license, which in my opinion is really worth the money. It is a great tool, and I've been using it for many years now as my main code editor, and I think it's a little bit unfair to put the 'not free' notice, which might discourage our students from giving it a try.